### PR TITLE
Summarize Korean commit improvements for Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,20 @@ Questions/ideas: open an Issue or start an RFC under `docs/rfcs/`.
 - **MVP Scope**: [docs/tech/mvp-scope.md](docs/tech/mvp-scope.md)
 - **Development Roadmap**: [docs/tech/roadmap.md](docs/tech/roadmap.md)
 - **Contributing**: [docs/team/CONTRIBUTING.md](docs/team/CONTRIBUTING.md)
+
+---
+
+## 🔔 Slack: Recent Commits & Changelog (Korean)
+
+Send a Korean summary of recent Git commits and items from `docs/progress/CHANGELOG.md` to Slack.
+
+- Set env var: `SLACK_WEBHOOK_URL="https://hooks.slack.com/services/XXX/YYY/ZZZ"`
+- Run (dry-run if no webhook set):
+  - `npm run report:slack` (defaults: `--limit 10`)
+  - Optional: `npm run report:slack -- --limit 20 --since "2 weeks ago"`
+  - Optional: `npm run report:slack -- --changelog docs/progress/CHANGELOG.md`
+
+The message includes:
+- 최근 커밋 목록: 날짜, 해시, 제목, 작성자
+- CHANGELOG(Unreleased) 주요 변경사항 요약
+- 자동 생성 안내 문구

--- a/navo/scripts/sendSlackChangelog.ts
+++ b/navo/scripts/sendSlackChangelog.ts
@@ -1,0 +1,139 @@
+import { execSync } from 'node:child_process';
+
+interface CommitEntry {
+  shortHash: string;
+  author: string;
+  date: string;
+  subject: string;
+}
+
+interface CliOptions {
+  limit: number;
+  since?: string;
+  changelogPath: string;
+}
+
+function parseCliArgs(argv: string[]): CliOptions {
+  const defaultOptions: CliOptions = {
+    limit: 10,
+    changelogPath: 'docs/progress/CHANGELOG.md',
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--limit' && i + 1 < argv.length) {
+      defaultOptions.limit = Number(argv[++i]) || defaultOptions.limit;
+    } else if (arg === '--since' && i + 1 < argv.length) {
+      defaultOptions.since = argv[++i];
+    } else if (arg === '--changelog' && i + 1 < argv.length) {
+      defaultOptions.changelogPath = argv[++i];
+    }
+  }
+
+  return defaultOptions;
+}
+
+function getRecentCommits(options: CliOptions): CommitEntry[] {
+  const sincePart = options.since ? ` --since="${options.since}"` : '';
+  const cmd = `git log -n ${options.limit}${sincePart} --date=short --pretty=format:'%h|%an|%ad|%s'`;
+  try {
+    const stdout = execSync(cmd, { encoding: 'utf8' });
+    const lines = stdout.split('\n').filter(Boolean);
+    return lines.map((line) => {
+      const [shortHash, author, date, subject] = line.split('|');
+      return { shortHash, author, date, subject };
+    });
+  } catch (error) {
+    console.error('git log 실행 중 오류가 발생했습니다.', error);
+    return [];
+  }
+}
+
+function readChangelog(path: string): string[] {
+  try {
+    const content = execSync(`cat ${path}`, { encoding: 'utf8' });
+    const lines = content.split('\n');
+
+    const startIdx = lines.findIndex((l) => l.trim().toLowerCase() === '## unreleased');
+    if (startIdx === -1) return [];
+
+    // Collect bullet points under Added/Changed/Fixed until next header (##)
+    const items: string[] = [];
+    for (let i = startIdx + 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.startsWith('## ')) break;
+      // bullets start with '-' optionally preceded by spaces
+      if (/^\s*-\s+/.test(line)) {
+        items.push(line.replace(/^\s*-\s+/, '').trim());
+      }
+    }
+    return items;
+  } catch (error) {
+    console.warn('CHANGELOG을 읽는 중 오류가 발생했습니다.', error);
+    return [];
+  }
+}
+
+function buildSlackText(commits: CommitEntry[], changelogItems: string[], options: CliOptions): string {
+  const header = `*🧭 NAVO 업데이트 요약*`;
+
+  const commitHeader = `*최근 커밋 (${options.limit}개${options.since ? `, ${options.since} 이후` : ''})*`;
+  const commitLines = commits.length
+    ? commits
+        .map((c) => `• ${c.date} ${c.shortHash} — ${c.subject} _(by ${c.author})_`)
+        .join('\n')
+    : '최근 커밋 정보를 가져오지 못했습니다.';
+
+  const changelogHeader = '*CHANGELOG - Unreleased 주요 변경사항*';
+  const changelogLines = changelogItems.length
+    ? changelogItems.map((i) => `• ${i}`).join('\n')
+    : '변경 내역이 없거나 읽어올 수 없습니다.';
+
+  const footer = '_이 메시지는 자동 생성되었습니다._';
+
+  return [header, '', commitHeader, commitLines, '', changelogHeader, changelogLines, '', footer].join('\n');
+}
+
+async function postToSlack(webhookUrl: string, text: string): Promise<Response> {
+  // Node 18+ has global fetch
+  return fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+
+  const commits = getRecentCommits(options);
+  const changelogItems = readChangelog(options.changelogPath);
+  const text = buildSlackText(commits, changelogItems, options);
+
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    console.log('[DRY-RUN] SLACK_WEBHOOK_URL 미설정. 아래 메시지를 콘솔에 출력합니다:');
+    console.log('---');
+    console.log(text);
+    console.log('---');
+    process.exit(0);
+  }
+
+  try {
+    const res = await postToSlack(webhookUrl, text);
+    if (!res.ok) {
+      const errBody = await res.text();
+      console.error('Slack Webhook 전송 실패:', res.status, res.statusText, errBody);
+      process.exit(1);
+    }
+    console.log('Slack 전송 성공');
+  } catch (error) {
+    console.error('Slack Webhook 호출 중 오류:', error);
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "format": "prettier --write .",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
-    "db:pull": "drizzle-kit introspect"
-  },
-  "engines": {
-    "node": "22.x"
-  },
+          "db:pull": "drizzle-kit introspect",
+      "report:slack": "tsx navo/scripts/sendSlackChangelog.ts --limit 10"
+    },
+    "engines": {
+      "node": "22.x"
+    },
   "devDependencies": {
     "@types/bcryptjs": "^3.0.0",
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
Add a Slack reporting script to summarize recent commits and changelog in Korean.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e9a03b1-f23b-40c4-b657-b844f4767dca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e9a03b1-f23b-40c4-b657-b844f4767dca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

