### PR TITLE
Debug vercel build error with jest types

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -1,11 +1,10 @@
-import type { Config } from 'jest';
 import nextJest from 'next/jest';
 
 const createJestConfig = nextJest({
   dir: './',
 });
 
-const customJestConfig: Config = {
+const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {

--- a/frontend/src/components/ui/FileTree.tsx
+++ b/frontend/src/components/ui/FileTree.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { useListVfsNodes } from '@/hooks/api';
 import { useIdeStore } from '@/store/ideStore';
+import clsx from 'clsx';
 
 interface FileTreeProps {
   projectId: string;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,5 +24,13 @@
     "types": ["jest", "node"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "jest.config.ts",
+    "jest.setup.ts",
+    "test",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**"
+  ]
 }


### PR DESCRIPTION
Fix Vercel build error by adjusting Jest config type import and excluding test files from Next.js type-checking, and adding a missing `clsx` import.

The primary issue was a TypeScript error (`File '...' is not a module`) during the Next.js build when it attempted to type-check `jest.config.ts`. This was resolved by removing the explicit `Config` type import from `jest` and configuring `tsconfig.json` to exclude Jest configuration and test files from the Next.js build's type-checking process. A subsequent compilation error regarding a missing `clsx` import in `FileTree.tsx` was also addressed.

---
<a href="https://cursor.com/background-agent?bcId=bc-229787ef-cbe9-4cf7-9ff5-13fa70581f80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-229787ef-cbe9-4cf7-9ff5-13fa70581f80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

