### PR TITLE
Analyze render deploy error log

### DIFF
--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,6 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"],
   "references": []
 }


### PR DESCRIPTION
Exclude test files from `packages/shared` TypeScript build to resolve Render CI build failure.

The Render deploy failed because `tsc` in the `@navo/shared` package was attempting to type-check test files, which is not intended for production builds. This change updates `packages/shared/tsconfig.json` to explicitly exclude `**/*.test.ts` and `**/__tests__/**` files.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c514690-0d63-42c0-8fa0-d8761a2e5cec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c514690-0d63-42c0-8fa0-d8761a2e5cec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

